### PR TITLE
octez rollup: support for several operator types

### DIFF
--- a/charts/tezos/scripts/smart-rollup-node.sh
+++ b/charts/tezos/scripts/smart-rollup-node.sh
@@ -12,7 +12,7 @@ cp /usr/local/share/tezos/evm_kernel/* "$ROLLUP_DATA_DIR_PREIMAGES"
 CMD="$TEZ_BIN/octez-smart-rollup-node \
   --endpoint http://tezos-node-rpc:8732 \
   -d $CLIENT_DIR \
-  run operator for ${ROLLUP_ADDRESS} with operators ${OPERATOR_ACCOUNT} \
+  run operator for ${ROLLUP_ADDRESS} with operators ${OPERATORS_PARAMS} \
   --data-dir ${ROLLUP_DATA_DIR} \
   --boot-sector-file /var/tezos/smart-rollup-boot-sector \
   --rpc-addr 0.0.0.0"

--- a/charts/tezos/templates/octez-rollup-node.yaml
+++ b/charts/tezos/templates/octez-rollup-node.yaml
@@ -153,8 +153,12 @@ spec:
         env:
           - name: ROLLUP_ADDRESS
             value: {{ $v.rollup_address }}
-          - name: OPERATOR_ACCOUNT
-            value: {{ $v.operator_account }}
+          - name: OPERATORS_PARAMS
+            value: >
+              {{- range $key, $value := $v.operators }}
+              {{- $cleanKey := regexReplaceAll "[0-9]+$" $key "" }}
+              {{ $cleanKey }}:{{ $value }}
+              {{- end }}
       initContainers:
       - image: {{ $.Values.tezos_k8s_images.utils }}
         imagePullPolicy: {{ $.Values.tezos_k8s_images_pull_policy }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -362,7 +362,14 @@ smartRollupNodes: {}
 # ```
 # smartRollupNodes:
 #   rollup-node-0:
-#     operator_account: archive-baking-node-0
+#     operators:
+#       operating: archive-baking-node-0
+#       cementing: archive-baking-node-0
+#       executing_outbox: archive-baking-node-0
+#       batching1: batcher1-account
+#       batching2: batcher2-account
+#       batching3: batcher3-account
+#       batching4: batcher4-account
 #     rollup_address: sr1RYurGZtN8KNSpkMcCt9CgWeUaNkzsAfXf
 #     annotations: {}
 #     ingress:

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -237,7 +237,11 @@ def expose_secret_key(account_name):
         return account_name in MY_POD_CONFIG.get("accounts")
 
     if MY_POD_TYPE == "rollup":
-        return account_name == MY_POD_CONFIG.get("operator_account")
+        operators = MY_POD_CONFIG.get("operators")
+        if operators is not None:
+            return account_name in operators.values()
+        else:
+            return False
     if MY_POD_TYPE in ["node", "baker"]:
         if account_name in MY_POD_CONFIG.get("authorized_keys", {}):
             return True


### PR DESCRIPTION
Instead of one operator doing everything, we have several roles.

In values.yaml, under smartRollupNodes: you can now define a list of operator key-value pairs under `operators:`. They will be passed to the rollup as parameters.

Note that you can pass several operators of the same name like "batcher" but the yaml syntax prevents it, so we are adding numbers such as "batcher1" to the keys, then pruning them before passing them to octez-dal-node.