### PR TITLE
Initial setup to take out tzkt from tezos chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 *.eggs
 .venv*
 .DS_Store
+.idea
 .vscode
 node_modules
 

--- a/charts/tzkt/.helmignore
+++ b/charts/tzkt/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tzkt/Chart.yaml
+++ b/charts/tzkt/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tzkt
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.13.2"

--- a/charts/tzkt/templates/_helpers.tpl
+++ b/charts/tzkt/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tzkt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tzkt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tzkt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tzkt.labels" -}}
+helm.sh/chart: {{ include "tzkt.chart" . }}
+{{ include "tzkt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tzkt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tzkt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tzkt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tzkt.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* tzkt db connection string */}}
+{{- define "tzkt.connectionString" -}}
+{{ print " " "server=$(POSTGRES_HOST);port=$(POSTGRES_PORT);database=$(POSTGRES_DB);username=$(POSTGRES_USER);password=$(POSTGRES_PASSWORD);command timeout=$(POSTGRES_COMMAND_TIMEOUT);" }}
+{{- end -}}
+
+{{/* tzkt api httl url */}}
+{{- define "tzkt.apiUrl" -}}
+{{ print "http://0.0.0.0:%s" .Values.api.port }}
+{{- end -}}

--- a/charts/tzkt/templates/configmap-api.yaml
+++ b/charts/tzkt/templates/configmap-api.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.api.appSettings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tzkt.fullname" . }}-api-app
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+data:
+  appsettings.json: |-
+    {{ .Values.api.appSettings | nindent 4 }}
+{{- end }}

--- a/charts/tzkt/templates/configmap-sync.yaml
+++ b/charts/tzkt/templates/configmap-sync.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.sync.appSettings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tzkt.fullname" . }}-sync-app
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+data:
+  appsettings.json: |-
+    {{ .Values.sync.appSettings | nindent 4 }}
+{{- end }}

--- a/charts/tzkt/templates/secret.yaml
+++ b/charts/tzkt/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tzkt.fullname" . }}-db-creds
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+data:
+  POSTGRES_HOST: {{ b64enc .Values.externalDatabase.host }}
+  POSTGRES_USER: {{ b64enc .Values.externalDatabase.user }}
+  POSTGRES_PASSWORD: {{ b64enc .Values.externalDatabase.password }}
+  POSTGRES_DB: {{ b64enc .Values.externalDatabase.database }}
+  POSTGRES_COMMAND_TIMEOUT: {{ b64enc .Values.externalDatabase.commandTimeout }}

--- a/charts/tzkt/templates/service.yaml
+++ b/charts/tzkt/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tzkt.fullname" . }}
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tzkt.selectorLabels" . | nindent 4 }}

--- a/charts/tzkt/templates/serviceaccount.yaml
+++ b/charts/tzkt/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tzkt.serviceAccountName" . }}
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tzkt/templates/statefulset.yaml
+++ b/charts/tzkt/templates/statefulset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "tzkt.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "tzkt.selectorLabels" . | nindent 6 }}
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        {{- include "tzkt.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - image: {{ .Values.tezos_k8s_images.utils }}
+          name: readiness
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while :
+              do
+                [ "$(curl -s http://localhost:5000/v1/head | jq '.synced')" = true ] \
+                  && { touch /tmp/synced; echo "Synced"; } \
+                  || { echo "Indexer syncing..."; rm -f /tmp/synced; }
+                sleep 8s
+              done
+          {{- /*
+            initialDelaySeconds gives indexer time to boot up and grab chain data
+            before starting the probe. Also some blocks can take longer than others
+            to sync, such as when fetching baking/endorsing rights for a cycle.
+            So we set failureThreshold to 3. Tzkt has a bug where occasionally the
+            indexer sync status returns a false positive. Usually when the container
+            just starts. We set the successThreshold at 2 so we are more likely to
+            know if the indexer is actually synced.
+          */}}
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 2
+            exec:
+              command: ["cat", "/tmp/synced"]
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: "{{ .Values.api.image.pullPolicy }}"
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          env:
+            - name: Logging__LogLevel__Default
+              value: {{ .Values.api.logLevel }}
+            - name: ConnectionStrings__DefaultConnection
+              value: {{- include "tzkt.connectionString" . }}
+            - name: TZKT_API_KESTREL__ENDPOINTS__HTTP__URL
+              value: {{- include "tzkt.apiUrl" }}
+          envFrom:
+            - secretRef:
+                name: {{ include "tzkt.fullname" . }}-db-creds
+        - name: indexer
+          image: "{{ .Values.sync.image.repository }}:{{ .Values.sync.image.tag}}"
+          imagePullPolicy: "{{ .Values.sync.image.pullPolicy }}"
+          volumeMounts:
+            - name: tzkt-env
+              mountPath: /etc/tzkt
+          env:
+            - name: Logging__LogLevel__Default
+              value: {{ .Values.sync.logLevel }}
+            - name: TezosNode__Endpoint
+              value: {{ .Values.sync.tezosNodeEndpoint }}
+            - name: ConnectionStrings__DefaultConnection
+              value: {{- include "tzkt.connectionString" . }}
+          envFrom:
+            - secretRef:
+                name: {{ include "tzkt.fullname" . }}-db-creds
+      volumes:
+        - name: tzkt-env
+          emptyDir: {}

--- a/charts/tzkt/templates/tests/test-connection.yaml
+++ b/charts/tzkt/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "tzkt.fullname" . }}-test-connection"
+  labels:
+    {{- include "tzkt.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "tzkt.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/tzkt/values.yaml
+++ b/charts/tzkt/values.yaml
@@ -1,0 +1,114 @@
+# Default values for tzkt.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+tezos_k8s_images:
+  utils: ghcr.io/tacoinfra/tezos-k8s-utils:main
+
+## @section tzkt api configuration
+##
+api:
+  ## tzkt api image parameters
+  image:
+    repository: bakingbad/tzkt-api
+    tag: v1.13.2
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param port for tzkt api service
+  port: 5000
+  ## @param log level for tzkt api
+  logLevel: Information
+  ## @param appSettings Custom appSettings to run api,
+  ## e.g:
+  ## appSettings:
+  ##   {
+  ##     "Cache": {
+  ##       "LoadRate": 0.75,
+  ##       "MaxAccounts": 32000
+  ##     },
+  ##     ....
+  ##     "ResponseCache": {
+  ##       "CacheSize": 256
+  ##     },
+  ##     ....
+  ##    }
+  appSettings: {}
+
+## @section tzkt sync configuration
+##
+sync:
+  ## tzkt sync image parameters
+  image:
+    repository: bakingbad/tzkt-sync
+    tag: v1.13.2
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param tezos endpoint to point for indexing,
+  tezosNodeEndpoint: 'https://rpc.tzkt.io/mainnet/'
+  ## @param log level for tzkt sync
+  logLevel: Information
+  ## @param appSettings Custom appSettings to run api,
+  ## e.g:
+  ## appSettings:
+  ##   {
+  ##     "Protocols": {
+  ##       "Diagnostics": false,
+  ##       "Validation": true,
+  ##       "Fallback": null
+  ##     },
+  ##     "TezosNode": {
+  ##       "Endpoint": "https://rpc.tzkt.io/mainnet/",
+  ##       "Timeout": 60
+  ##     },
+  ##     "Quotes": {
+  ##       "Async": true,
+  ##       "Provider": {
+  ##         "Name": "TzktQuotes"
+  ##       }
+  ##     },
+  ##     ....
+  ##   }
+  appSettings: {}
+
+
+## External Database Configuration
+##
+externalDatabase:
+  ## @param externalDatabase.host External Database server host
+  ##
+  host: localhost
+  ## @param externalDatabase.port External Database server port
+  ##
+  port: 5432
+  ## @param externalDatabase.user External Database username
+  ##
+  user: "tzkt"
+  ## @param externalDatabase.password External Database user password
+  ##
+  password: ""
+  ## @param externalDatabase.database External Database database name
+  ##
+  database: "tzkt_db"
+  ## @param externalDatabase.commandTimeout Timeout of the DB command
+  commandTimeout: "600"


### PR DESCRIPTION
This is an effort to make tzkt helm chart a dedicated one, the reason to is that tzkt is an indexer app on top tezos nodes.
To make its own chart would make make the tezos chart more octez oriented and increase the readability for the tzkt chart.

There is need to config the tzkt via configmap after the production deployment of tzkt on our setup, this PR will implement that also