### PR TITLE
add ability to define a node selector for baker

### DIFF
--- a/charts/tezos/templates/octez-baker.yaml
+++ b/charts/tezos/templates/octez-baker.yaml
@@ -1,4 +1,5 @@
 {{- range $k, $v := .Values.bakers }}
+{{- $_ := set $ "node_vals" $v }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -73,6 +74,7 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
+{{- include "tezos.nodeSelectorConfig" $ | indent 6 }}
       volumes:
         - name: baker-config
           configMap:

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -275,6 +275,8 @@ bakers: {}
   #   node_rpc_url: http://octez-node-0:8732
   #   operations_pool: http://flashbake-endpoint:10732
   #   dal_node_rpc_url: http://dal-node:8732
+  #   node_selector:
+  #     nodeSelectorKey: nodeSelectorValue
 
 ## Configuration for K8s Service resources. Configuring the labels selector of a
 ## service will result in the service forwarding traffic only to pods that have


### PR DESCRIPTION
Previously this ability was only for node pods (which include baker). But with remote baker, we need this ability for the baker pod as well.