### PR TITLE
move mkchain to ParisC

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -504,7 +504,7 @@ protocols:
   ##   "on" and "off" must be between quotes.
   ## Note that we are not providing default votes since every baker needs
   ## to make an explicit educated choice on every toggle.
-  - command: Proxford
+  - command: PsParisC
     vote: {}
   # - command: alpha
   #   vote:
@@ -517,30 +517,37 @@ protocols:
 ## after chain activation.
 ##
 # activation:
-#  protocol_hash: ProxfordYmVfjWnRcgjWH36fW6PArwqykTFzotUxRs6gmTcZDuH
+#  protocol_hash: PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi
 #  protocol_parameters:
-#    preserved_cycles: 3
 #    blocks_per_cycle: 8
 #    blocks_per_commitment: 4
-#    blocks_per_stake_snapshot: 4
 #    cycles_per_voting_period: 1
 #    hard_gas_limit_per_operation: '1040000'
 #    hard_gas_limit_per_block: '5200000'
 #    proof_of_work_threshold: '-1'
 #    minimal_stake: '6000000000'
 #    minimal_frozen_stake: '600000000'
-#    adaptive_issuance_launch_ema_threshold: 10000000
-#    adaptive_issuance_activation_vote_enable: false
+#    adaptive_issuance_launch_ema_threshold: 0
+#    adaptive_issuance_activation_vote_enable: true
+#    adaptive_issuance_force_activation: false
 #    autostaking_enable: true
 #    global_limit_of_staking_over_baking: 5
 #    edge_of_staking_over_delegation: 2
 #    adaptive_rewards_params:
-#      issuance_ratio_min:
+#      issuance_ratio_final_min:
 #        numerator: "1"
-#        denominator: "200"
-#      issuance_ratio_max:
+#        denominator: "400"
+#      issuance_ratio_final_max:
 #        numerator: "1"
 #        denominator: "10"
+#      issuance_ratio_initial_min:
+#        numerator: "9"
+#        denominator: "200"
+#      issuance_ratio_initial_max:
+#        numerator: "11"
+#        denominator: "200"
+#      initial_period: 10
+#      transition_period: 50
 #      max_bonus: "50000000000000"
 #      growth_rate:
 #        numerator: "1"
@@ -556,7 +563,6 @@ protocols:
 #      baking_reward_fixed_portion_weight: 5120
 #      baking_reward_bonus_weight: 5120
 #      attesting_reward_weight: 10240
-#      liquidity_baking_subsidy_weight: 1280
 #      vdf_revelation_tip_weight: 1
 #      seed_nonce_revelation_tip_weight: 1
 #    hard_storage_limit_per_operation: '60000'
@@ -565,6 +571,7 @@ protocols:
 #    quorum_max: 7000
 #    quorum_min: 2000
 #    min_proposal_quorum: 500
+#    liquidity_baking_subsidy: "5000000"
 #    liquidity_baking_toggle_ema_threshold: 100000
 #    max_operations_time_to_live: 120
 #    minimal_block_delay: "5"
@@ -575,8 +582,8 @@ protocols:
 #      numerator: 2
 #      denominator: 3
 #    limit_of_delegation_over_baking: 9
-#    percentage_of_frozen_deposits_slashed_per_double_baking: 7
-#    percentage_of_frozen_deposits_slashed_per_double_attestation: 50
+#    percentage_of_frozen_deposits_slashed_per_double_baking: 700
+#    percentage_of_frozen_deposits_slashed_per_double_attestation: 5000
 #    cache_script_size: 100000000
 #    cache_stake_distribution_cycles: 8
 #    cache_sampler_state_cycles: 8
@@ -584,6 +591,7 @@ protocols:
 #    vdf_difficulty: '100000'
 #    dal_parametric:
 #      feature_enable: true
+#      incentives_enable: false
 #      number_of_slots: 256
 #      number_of_shards: 2048
 #      attestation_lag: 2
@@ -591,7 +599,6 @@ protocols:
 #      slot_size: 65536
 #      redundancy_factor: 16
 #      page_size: 4096
-#      blocks_per_epoch: 8
 #    smart_rollup_private_enable: true
 #    smart_rollup_riscv_pvm_enable: true
 #    smart_rollup_origination_size: 6314
@@ -610,12 +617,20 @@ protocols:
 #      raw_data:
 #        Blake2B: 0
 #      metadata: 0
-#      dal_page: 0
-#      dal_parameters: 0
+#      dal_page: 1
+#      dal_parameters: 1
+#      dal_attested_slots_validity_lag: 241920
 #    zk_rollup_enable: true
 #    zk_rollup_origination_size: 4000
 #    zk_rollup_min_pending_to_process: 10
 #    zk_rollup_max_ticket_payload_size: 2048
+#    blocks_preservation_cycles: 1
+#    consensus_rights_delay: 2
+#    delegate_parameters_activation_delay: 3
+#    direct_ticket_spending_enable: false
+#    max_slashing_per_block: 10000
+#    max_slashing_threshold: 2334
+#    ns_enable: true
 #
 #   # Pass url pointing to additional contracts that you want injected at activation.
 #   # This data is typically too large to pass it directly inside helm chart.

--- a/docs/Baker.md
+++ b/docs/Baker.md
@@ -18,7 +18,7 @@ node_globals:
     all:
       TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
 protocols:
-  - command: Proxford # replace with the most recent protocol
+  - command: PtParisC # replace with the most recent protocol
     vote:
       liquidity_baking_toggle_vote: pass
 accounts:
@@ -68,7 +68,7 @@ Configure a mainnet signer as follows:
 images:
   octez: tezos/tezos:octez-v20.2 # replace with most recent version
 protocols:
-  - command: Proxford # replace with the most recent protocol
+  - command: PsParisC # replace with the most recent protocol
     vote:
       liquidity_baking_toggle_vote: pass
 accounts:

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -165,7 +165,7 @@ def main():
         },
         "protocols": [
             {
-                "command": "Proxford",
+                "command": "PsParisC",
                 "vote": {"liquidity_baking_toggle_vote": "pass"},
             }
         ],
@@ -312,7 +312,7 @@ def main():
         parametersYaml = yaml.safe_load(yaml_file)
         activation = {
             "activation": {
-                "protocol_hash": "ProxfordYmVfjWnRcgjWH36fW6PArwqykTFzotUxRs6gmTcZDuH",
+                "protocol_hash": "PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi",
                 "protocol_parameters": parametersYaml,
             },
         }

--- a/mkchain/tqchain/parameters.yaml
+++ b/mkchain/tqchain/parameters.yaml
@@ -1,25 +1,32 @@
-preserved_cycles: 3
 blocks_per_cycle: 8
 blocks_per_commitment: 4
-blocks_per_stake_snapshot: 4
 cycles_per_voting_period: 1
 hard_gas_limit_per_operation: '1040000'
 hard_gas_limit_per_block: '5200000'
 proof_of_work_threshold: '-1'
 minimal_stake: '6000000000'
 minimal_frozen_stake: '600000000'
-adaptive_issuance_launch_ema_threshold: 10000000
-adaptive_issuance_activation_vote_enable: false
+adaptive_issuance_launch_ema_threshold: 0
+adaptive_issuance_activation_vote_enable: true
+adaptive_issuance_force_activation: false
 autostaking_enable: true
 global_limit_of_staking_over_baking: 5
 edge_of_staking_over_delegation: 2
 adaptive_rewards_params:
-  issuance_ratio_min:
+  issuance_ratio_final_min:
     numerator: "1"
-    denominator: "200"
-  issuance_ratio_max:
+    denominator: "400"
+  issuance_ratio_final_max:
     numerator: "1"
     denominator: "10"
+  issuance_ratio_initial_min:
+    numerator: "9"
+    denominator: "200"
+  issuance_ratio_initial_max:
+    numerator: "11"
+    denominator: "200"
+  initial_period: 10
+  transition_period: 50
   max_bonus: "50000000000000"
   growth_rate:
     numerator: "1"
@@ -35,7 +42,6 @@ issuance_weights:
   baking_reward_fixed_portion_weight: 5120
   baking_reward_bonus_weight: 5120
   attesting_reward_weight: 10240
-  liquidity_baking_subsidy_weight: 1280
   vdf_revelation_tip_weight: 1
   seed_nonce_revelation_tip_weight: 1
 hard_storage_limit_per_operation: '60000'
@@ -44,6 +50,7 @@ cost_per_byte: '250'
 quorum_max: 7000
 quorum_min: 2000
 min_proposal_quorum: 500
+liquidity_baking_subsidy: "5000000"
 liquidity_baking_toggle_ema_threshold: 100000
 max_operations_time_to_live: 120
 minimal_block_delay: "5"
@@ -54,8 +61,8 @@ minimal_participation_ratio:
   numerator: 2
   denominator: 3
 limit_of_delegation_over_baking: 9
-percentage_of_frozen_deposits_slashed_per_double_baking: 7
-percentage_of_frozen_deposits_slashed_per_double_attestation: 50
+percentage_of_frozen_deposits_slashed_per_double_baking: 700
+percentage_of_frozen_deposits_slashed_per_double_attestation: 5000
 cache_script_size: 100000000
 cache_stake_distribution_cycles: 8
 cache_sampler_state_cycles: 8
@@ -63,6 +70,7 @@ nonce_revelation_threshold: 4
 vdf_difficulty: '100000'
 dal_parametric:
   feature_enable: true
+  incentives_enable: false
   number_of_slots: 256
   number_of_shards: 2048
   attestation_lag: 2
@@ -70,7 +78,6 @@ dal_parametric:
   slot_size: 65536
   redundancy_factor: 16
   page_size: 4096
-  blocks_per_epoch: 8
 smart_rollup_private_enable: true
 smart_rollup_riscv_pvm_enable: true
 smart_rollup_origination_size: 6314
@@ -89,9 +96,17 @@ smart_rollup_reveal_activation_level:
   raw_data:
     Blake2B: 0
   metadata: 0
-  dal_page: 0
-  dal_parameters: 0
+  dal_page: 1
+  dal_parameters: 1
+  dal_attested_slots_validity_lag: 241920
 zk_rollup_enable: true
 zk_rollup_origination_size: 4000
 zk_rollup_min_pending_to_process: 10
 zk_rollup_max_ticket_payload_size: 2048
+blocks_preservation_cycles: 1
+consensus_rights_delay: 2
+delegate_parameters_activation_delay: 3
+direct_ticket_spending_enable: false
+max_slashing_per_block: 10000
+max_slashing_threshold: 2334
+ns_enable: true


### PR DESCRIPTION
* set new proto params for mkchain
* replace all occurrences of oxford with paris in docs, etc
* launch ParisC baker by default

Oxford is absent in v20 container and beyond so mkchain is currently broken.

Tested that "mkchain" with no parameters generates a values.yaml which, when deployed, activates a chain and spins up a baker that generates blocks.