### PR TITLE
chore: bump octez to v22.1 and Python to 3.12

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -1,6 +1,6 @@
 # Images not part of the tezos-k8s repo go here
 images:
-  octez: tezos/tezos:octez-v20.2
+  octez: tezos/tezos:octez-v22.1
   tacoinfraRemoteSigner: ghcr.io/tacoinfra/tacoinfra-remote-signer:0.1.0
 images_pull_policy: IfNotPresent
 # Images that are part of the tezos-k8s repo go here with 'dev' tag
@@ -339,7 +339,7 @@ serviceMonitor:
 # https://tezos.gitlab.io/user/key-management.html#signer
 octezSigners: {}
 # These signers use the octez-signer binary.
-# 
+#
 # Example:
 # ```
 # octezSigners:

--- a/docs/Baker.md
+++ b/docs/Baker.md
@@ -10,7 +10,7 @@ The below `values.yaml` will start a ghostnet baker:
 
 ```
 images:
-  octez: tezos/tezos:octez-v20.2 # replace with most recent version
+  octez: tezos/tezos:octez-v22.1 # replace with most recent version
 node_config_network:
   chain_name: ghostnet
 node_globals:
@@ -66,7 +66,7 @@ Configure a mainnet signer as follows:
 
 ```
 images:
-  octez: tezos/tezos:octez-v20.2 # replace with most recent version
+  octez: tezos/tezos:octez-v22.1 # replace with most recent version
 protocols:
   - command: PsParisC # replace with the most recent protocol
     vote:

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -86,7 +86,7 @@ You can explicitly specify some values by:
 |                                  | --dal-nodes        | Number of DAL nodes in the cluster                      | 1                       |
 | bootstrap_peers                  | --bootstrap-peers        | Peer ips to connect to                                         | []                      |
 | expected_proof_of_work           | --expected-proof-of-work | Node identity generation difficulty                            | 0                       |
-| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:octez-v20.2 |
+| images.octez                     | --octez-docker-image     | Version of the Octez docker image to run                       | tezos/tezos:octez-v22.1 |
 |                                  | --use-docker (--no...)   | Use (or don't use) docker to generate keys rather than pytezos | autodetect              |
 
 ## Create Tezos Chain

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -71,7 +71,7 @@ cli_args = {
     },
     "octez_docker_image": {
         "help": "Version of the Octez docker image",
-        "default": "tezos/tezos:octez-v20.2",
+        "default": "tezos/tezos:octez-v22.1",
     },
     "use_docker": {
         "action": "store_true",

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -35,7 +35,7 @@ data:
   PREFER_TARBALLS: "false"
   SNAPSHOT_METADATA_NETWORK_NAME: ""
   SNAPSHOT_SOURCE: "https://snapshots.tezos.marigold.dev/api/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:octez-v20.2"
+  OCTEZ_VERSION: "tezos/tezos:octez-v22.1"
   NODE_GLOBALS: |
     {
       "config": {},
@@ -135,9 +135,9 @@ spec:
         appType: octez-node
         node_class: rolling-node
     spec:
-      containers:        
+      containers:
         - name: octez-node
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -145,27 +145,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-              
+
               set -xe
-              
+
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-              
+
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-              
+
               #
               # Keep the container alive for troubleshooting on failures:
-              
+
               sleep 3600
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -185,7 +185,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                                
+              port: 31732
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -194,7 +194,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -218,10 +218,10 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi        
-      initContainers:        
+              memory: 80Mi
+      initContainers:
         - name: config-init
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -229,10 +229,10 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
+
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -240,20 +240,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-              
+
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-              
+
               cat /etc/tezos/data/config.json
-              
+
               printf "\n\n\n\n\n\n\n"
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -272,7 +272,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -281,7 +281,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -302,7 +302,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts        
+              name: tezos-accounts
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -311,7 +311,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -330,9 +330,9 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: snapshot-importer
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -340,41 +340,41 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              
+
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-              
+
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-              
+
               cp -v /etc/tezos/config.json ${node_data_dir}
-              
+
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-              
+
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-              
+
               rm -rvf ${snapshot_file}
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -393,9 +393,9 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume                
+              name: var-volume
         - name: upgrade-storage
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -403,14 +403,14 @@ spec:
             - "-c"
             - |
               set -ex
-              
+
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -421,7 +421,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000      
+        fsGroup: 1000
       volumes:
         - emptyDir: {}
           name: config-volume

--- a/test/charts/mainnet.expect.yaml
+++ b/test/charts/mainnet.expect.yaml
@@ -135,7 +135,7 @@ spec:
         appType: octez-node
         node_class: rolling-node
     spec:
-      containers:
+      containers:        
         - name: octez-node
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -145,27 +145,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-
+              
               set -xe
-
+              
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-
+              
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-
+              
               #
               # Keep the container alive for troubleshooting on failures:
-
+              
               sleep 3600
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -185,7 +185,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732
+              port: 31732                                
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -194,7 +194,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -218,8 +218,8 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi
-      initContainers:
+              memory: 80Mi        
+      initContainers:        
         - name: config-init
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -229,10 +229,10 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-
+              
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -240,20 +240,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-
+              
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-
+              
               cat /etc/tezos/data/config.json
-
+              
               printf "\n\n\n\n\n\n\n"
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -272,7 +272,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -281,7 +281,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -302,7 +302,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts
+              name: tezos-accounts        
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -311,7 +311,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -330,7 +330,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: snapshot-importer
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -340,41 +340,41 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-
+              
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-
+              
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-
+              
               cp -v /etc/tezos/config.json ${node_data_dir}
-
+              
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-
+              
               rm -rvf ${snapshot_file}
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -393,7 +393,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume                
         - name: upgrade-storage
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -403,14 +403,14 @@ spec:
             - "-c"
             - |
               set -ex
-
+              
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -421,7 +421,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000
+        fsGroup: 1000      
       volumes:
         - emptyDir: {}
           name: config-volume

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -35,7 +35,7 @@ data:
   PREFER_TARBALLS: "false"
   SNAPSHOT_METADATA_NETWORK_NAME: ""
   SNAPSHOT_SOURCE: "https://snapshots.tezos.marigold.dev/api/tezos-snapshots.json"
-  OCTEZ_VERSION: "tezos/tezos:octez-v20.2"
+  OCTEZ_VERSION: "tezos/tezos:octez-v22.1"
   NODE_GLOBALS: |
     {
       "config": {},
@@ -204,9 +204,9 @@ spec:
         appType: octez-node
         node_class: city-block
     spec:
-      containers:        
+      containers:
         - name: octez-node
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -214,27 +214,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-              
+
               set -xe
-              
+
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-              
+
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-              
+
               #
               # Keep the container alive for troubleshooting on failures:
-              
+
               sleep 3600
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -258,7 +258,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732                        
+              port: 31732
         - name: logger
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -267,7 +267,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -288,7 +288,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -297,7 +297,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -323,10 +323,10 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi        
-      initContainers:        
+              memory: 80Mi
+      initContainers:
         - name: config-init
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -334,10 +334,10 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
+
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -345,20 +345,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-              
+
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-              
+
               cat /etc/tezos/data/config.json
-              
+
               printf "\n\n\n\n\n\n\n"
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -379,7 +379,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -388,7 +388,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -411,7 +411,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts        
+              name: tezos-accounts
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -420,7 +420,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -441,9 +441,9 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: snapshot-importer
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -451,41 +451,41 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              
+
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-              
+
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-              
+
               cp -v /etc/tezos/config.json ${node_data_dir}
-              
+
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-              
+
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-              
+
               rm -rvf ${snapshot_file}
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -506,9 +506,9 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume                
+              name: var-volume
         - name: upgrade-storage
-          image: "tezos/tezos:octez-v20.2"
+          image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -516,14 +516,14 @@ spec:
             - "-c"
             - |
               set -ex
-              
+
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -536,7 +536,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000      
+        fsGroup: 1000
       volumes:
         - emptyDir: {}
           name: config-volume
@@ -573,7 +573,7 @@ spec:
         appType: octez-node
         node_class: country-town
     spec:
-      containers:        
+      containers:
         - name: octez-node
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -583,27 +583,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-              
+
               set -xe
-              
+
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-              
+
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-              
+
               #
               # Keep the container alive for troubleshooting on failures:
-              
+
               sleep 3600
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -644,7 +644,7 @@ spec:
             limits:
               memory: 16192Mi
             requests:
-              memory: 16192Mi                        
+              memory: 16192Mi
         - name: logger
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -653,7 +653,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -674,7 +674,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -683,7 +683,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -709,8 +709,8 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi        
-      initContainers:        
+              memory: 80Mi
+      initContainers:
         - name: config-init
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -720,10 +720,10 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-              
+
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -731,20 +731,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-              
+
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-              
+
               cat /etc/tezos/data/config.json
-              
+
               printf "\n\n\n\n\n\n\n"
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -765,7 +765,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -774,7 +774,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -797,7 +797,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts        
+              name: tezos-accounts
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -806,7 +806,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -827,7 +827,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume        
+              name: var-volume
         - name: snapshot-importer
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -837,41 +837,41 @@ spec:
             - "-c"
             - |
               set -e
-              
+
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-              
+
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-              
+
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-              
+
               cp -v /etc/tezos/config.json ${node_data_dir}
-              
+
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-              
+
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-              
+
               rm -rvf ${snapshot_file}
-              
+
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:    
+          env:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -892,7 +892,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume                
+              name: var-volume
         - name: upgrade-storage
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -902,14 +902,14 @@ spec:
             - "-c"
             - |
               set -ex
-              
+
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-              
+
           envFrom:
           env:
             - name: DAEMON
@@ -922,7 +922,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000      
+        fsGroup: 1000
       volumes:
         - emptyDir: {}
           name: config-volume

--- a/test/charts/mainnet2.expect.yaml
+++ b/test/charts/mainnet2.expect.yaml
@@ -204,7 +204,7 @@ spec:
         appType: octez-node
         node_class: city-block
     spec:
-      containers:
+      containers:        
         - name: octez-node
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -214,27 +214,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-
+              
               set -xe
-
+              
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-
+              
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-
+              
               #
               # Keep the container alive for troubleshooting on failures:
-
+              
               sleep 3600
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -258,7 +258,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /is_synced
-              port: 31732
+              port: 31732                        
         - name: logger
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -267,7 +267,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -288,7 +288,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -297,7 +297,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -323,8 +323,8 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi
-      initContainers:
+              memory: 80Mi        
+      initContainers:        
         - name: config-init
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -334,10 +334,10 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-
+              
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -345,20 +345,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-
+              
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-
+              
               cat /etc/tezos/data/config.json
-
+              
               printf "\n\n\n\n\n\n\n"
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -379,7 +379,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -388,7 +388,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -411,7 +411,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts
+              name: tezos-accounts        
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -420,7 +420,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -441,7 +441,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: snapshot-importer
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -451,41 +451,41 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-
+              
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-
+              
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-
+              
               cp -v /etc/tezos/config.json ${node_data_dir}
-
+              
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-
+              
               rm -rvf ${snapshot_file}
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -506,7 +506,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume                
         - name: upgrade-storage
           image: "tezos/tezos:octez-v22.1"
           imagePullPolicy: IfNotPresent
@@ -516,14 +516,14 @@ spec:
             - "-c"
             - |
               set -ex
-
+              
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -536,7 +536,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000
+        fsGroup: 1000      
       volumes:
         - emptyDir: {}
           name: config-volume
@@ -573,7 +573,7 @@ spec:
         appType: octez-node
         node_class: country-town
     spec:
-      containers:
+      containers:        
         - name: octez-node
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -583,27 +583,27 @@ spec:
             - "-c"
             - |
               #!/bin/sh
-
+              
               set -xe
-
+              
               # ensure we can run octez-client commands without specifying client dir
               ln -s /var/tezos/client /home/tezos/.tezos-client
               #
               # Not every error is fatal on start.
               # So, we try a few times with increasing delays:
-
+              
               for d in 1 1 5 10 20 60 120; do
               	/usr/local/bin/octez-node run				\
               			--bootstrap-threshold 0			\
               			--config-file /etc/tezos/config.json
               	sleep $d
               done
-
+              
               #
               # Keep the container alive for troubleshooting on failures:
-
+              
               sleep 3600
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -644,7 +644,7 @@ spec:
             limits:
               memory: 16192Mi
             requests:
-              memory: 16192Mi
+              memory: 16192Mi                        
         - name: logger
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -653,7 +653,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -674,7 +674,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: sidecar
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -683,7 +683,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -709,8 +709,8 @@ spec:
             limits:
               memory: 100Mi
             requests:
-              memory: 80Mi
-      initContainers:
+              memory: 80Mi        
+      initContainers:        
         - name: config-init
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -720,10 +720,10 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               echo "Writing custom configuration for public node"
               mkdir -p /etc/tezos/data
-
+              
               # if config already exists (container is rebooting), dump and delete it.
               if [ -e /etc/tezos/data/config.json ]; then
                 printf "Found pre-existing config.json:\n"
@@ -731,20 +731,20 @@ spec:
                 printf "Deleting\n"
                 rm -rvf /etc/tezos/data/config.json
               fi
-
+              
               /usr/local/bin/octez-node config init		\
                   --config-file /etc/tezos/data/config.json	\
                   --data-dir /etc/tezos/data			\
                   --network $CHAIN_NAME
-
+              
               cat /etc/tezos/data/config.json
-
+              
               printf "\n\n\n\n\n\n\n"
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -765,7 +765,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: config-generator
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -774,7 +774,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -797,7 +797,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
             - mountPath: /etc/secret-volume
-              name: tezos-accounts
+              name: tezos-accounts        
         - name: snapshot-downloader
           image: "ghcr.io/tacoinfra/tezos-k8s-utils:main"
           imagePullPolicy: IfNotPresent
@@ -806,7 +806,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -827,7 +827,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume        
         - name: snapshot-importer
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -837,41 +837,41 @@ spec:
             - "-c"
             - |
               set -e
-
+              
               bin_dir="/usr/local/bin"
               data_dir="/var/tezos"
               node_dir="$data_dir/node"
               node_data_dir="$node_dir/data"
               node="$bin_dir/octez-node"
               snapshot_file=${node_dir}/chain.snapshot
-
+              
               if [ ! -f ${snapshot_file} ]; then
                   echo "No snapshot to import."
                   exit 0
               fi
-
+              
               if [ -e ${node_data_dir}/context/store.dict ]; then
                   echo "Blockchain has already been imported. If a tarball"
                   echo "instead of a regular tezos snapshot was used, it was"
                   echo "imported in the snapshot-downloader container."
                   exit 0
               fi
-
+              
               cp -v /etc/tezos/config.json ${node_data_dir}
-
+              
               if [ -f ${node_dir}/chain.snapshot.block_hash ]; then
                   block_hash_arg="--block $(cat ${node_dir}/chain.snapshot.block_hash)"
               fi
-
+              
               ${node} snapshot import ${snapshot_file} --data-dir ${node_data_dir} --no-check
               find ${node_dir}
-
+              
               rm -rvf ${snapshot_file}
-
+              
           envFrom:
             - configMapRef:
                 name: tezos-config
-          env:
+          env:    
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -892,7 +892,7 @@ spec:
             - mountPath: /etc/tezos
               name: config-volume
             - mountPath: /var/tezos
-              name: var-volume
+              name: var-volume                
         - name: upgrade-storage
           image: "tezos/tezos:v15-release"
           imagePullPolicy: IfNotPresent
@@ -902,14 +902,14 @@ spec:
             - "-c"
             - |
               set -ex
-
+              
               if [ ! -e /var/tezos/node/data/context/store.dict ]
               then
                 printf "No store in data dir found, probably initial start, doing nothing."
                 exit 0
               fi
               octez-node upgrade storage --config /etc/tezos/config.json
-
+              
           envFrom:
           env:
             - name: DAEMON
@@ -922,7 +922,7 @@ spec:
             - mountPath: /var/tezos
               name: var-volume
       securityContext:
-        fsGroup: 1000
+        fsGroup: 1000      
       volumes:
         - emptyDir: {}
           name: config-volume

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.10-alpine
-# TODO: update to 3.11 once the bug is fixed:
-# https://github.com/baking-bad/pytezos/issues/336
+FROM python:3.12-alpine
 ENV PYTHONUNBUFFERED=1
 
 #


### PR DESCRIPTION
- Bump Octez to v22.1
- Bump Python to 3.12 (Bug https://github.com/baking-bad/pytezos/issues/336 has been fixed.)


~_**note**: Some trailing spaces were trimmed automatically by my editor but it shouldn't cause any issues._~

Trailing spaces restored for now. Caused issues in tests :disappointed: 